### PR TITLE
Fix compilation on Ubuntu 20.04

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -std=gnu11 $(GLIB_CFLAGS) -Wall -I$(top_srcdir)/ps2emu-kmod
-AM_LDFLAGS = $(GLIB_LIBS) $(GLIB_LDFLAGS)
+LIBS = $(GLIB_LIBS) $(GLIB_LDFLAGS)
 
 sbin_PROGRAMS = ps2emu-record \
                 ps2emu-replay


### PR DESCRIPTION
Not sure why, but Ubuntu 20.04 can not compile properly without this.

(see https://bugzilla.kernel.org/show_bug.cgi?id=209027#c5)

For the `ld` present in Ubuntu 20.04, the `-lglib-2.0` flags needs to be put at the end of the call, after the various `.o`.
While the current code works still fine on Fedora 32.

Anyway, with this, both Fedora 32 and Ubuntu 20.04 now compile.

Cc: @whot who might have some ideas on why this is required...